### PR TITLE
Fix NS_NONATOMIC_IOSONLY

### DIFF
--- a/include/Foundation/NSObjCRuntime.h
+++ b/include/Foundation/NSObjCRuntime.h
@@ -46,7 +46,11 @@
 #endif
 
 #if !defined(NS_NONATOMIC_IOSONLY)
-#define NS_NONATOMIC_IOSONLY nonatomic
+    #if TARGET_OS_OSX
+        #define NS_NONATOMIC_IOSONLY atomic
+    #else
+        #define NS_NONATOMIC_IOSONLY nonatomic
+    #endif
 #endif
 
 #if !defined(NS_NONATOMIC_IPHONEONLY)


### PR DESCRIPTION
I did some testing with MacOS and the XCode Simulator using the source code below. I can confirm that @bugaevc's theory is correct. Only macOS is `atomic` while everything else is `nonatomic`.

Also since `NS_NONATOMIC_IPHONEONLY` works exactly the same as `NS_NONATOMIC_IOSONLY`, I left it alone.

I have tested the code on XCode. The code also compiles fine on Darling.

Let me know if you need me to do any other changes.

---

```
#import <objc/message.h>

// Prints out weather the variable name is atomic or nonatomic.
void test_nonatomic_case(Class cls, const char *variable_name) {
    objc_property_t analysis = class_getProperty(cls, variable_name);
    
    if (analysis) {
        char *result = NULL;
                
        if ((result = property_copyAttributeValue(analysis, "N"))) {
            printf("It is nonatomic!\n");
        } else {
            printf("It is atomic!\n");
        }
        
        if (result != NULL) {
            free(result);
        }
    }
}
```