### PR TITLE
Implement NSScriptClassDescription category to NSObject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ set(foundation_sources
 	src/NSObjCRuntime.m
 	src/NSObjectInternal.m
 	src/NSObject+NSComparisonMethods.m
+	src/NSObject+NSScriptClassDescription.m
 	src/NSOperation.m
 	src/NSOrthographyCheckingResult.m
 	src/NSOrthography.m

--- a/include/Foundation/NSObject.h
+++ b/include/Foundation/NSObject.h
@@ -41,6 +41,13 @@
 
 @end
 
+@interface NSObject (NSScriptClassDescription)
+
+// @property(readonly) FourCharCode classCode;
+@property(readonly, copy) NSString *className;
+
+@end 
+
 @protocol NSDiscardableContent
 @required
 

--- a/src/NSObject+NSScriptClassDescription.m
+++ b/src/NSObject+NSScriptClassDescription.m
@@ -1,0 +1,10 @@
+#import <Foundation/NSObject.h>
+#import <Foundation/NSObjCRuntime.h>
+
+ @implementation NSObject (NSScriptClassDescription)
+
+ - (NSString *)className {
+    return NSStringFromClass([self class]);
+}
+
+ @end


### PR DESCRIPTION
When looking at the `nm` output, I noticed that `className` is a category implementation. Since I do not know how `classCode` is used, I focused on only implementing `className`.
```
-[NSObject(NSScriptClassDescription) classCode]
-[NSObject(NSScriptClassDescription) className]
```
One thing I found surprising about this implementation is that it also works as a class method as well (`[NSObject class]` actually returns `NSObject`).

When I was reading more about categories, I noticed that the naming convention is normally `NSObject+NSScriptClassDescription.h` and `NSObject+NSScriptClassDescription.m`. However, when I was looking the Foundation code, I was not sure where I should put the code.

If you don't like where I put the code, let me know where you want me to put it.
