### PR TITLE
Add New NSKeyedArchiver Method

### DIFF
--- a/include/Foundation/NSError.h
+++ b/include/Foundation/NSError.h
@@ -19,6 +19,8 @@ FOUNDATION_EXPORT NSString *const NSFilePathErrorKey;
 FOUNDATION_EXPORT NSString *const NSDebugDescriptionErrorKey;
 FOUNDATION_EXPORT NSString *const NSLocalizedFailureErrorKey;
 
+typedef NSString *NSErrorUserInfoKey;
+
 @interface NSError : NSObject <NSCopying, NSSecureCoding> {
 // NOTE: This is brittle - the ivar layout MUST be the same as CFErrorRef
     void *_reserved;

--- a/include/Foundation/NSKeyedArchiver.h
+++ b/include/Foundation/NSKeyedArchiver.h
@@ -1,3 +1,4 @@
+#import <Foundation/NSError.h>
 #import <Foundation/NSCoder.h>
 #import <Foundation/NSPropertyList.h>
 #import <CoreFoundation/CFDictionary.h>
@@ -53,6 +54,7 @@ typedef const struct __CFKeyedArchiverUID* CFKeyedArchiverUIDRef;
     CFMutableSetRef _visited;
 }
 
++ (NSData *)archivedDataWithRootObject:(id)object requiringSecureCoding:(BOOL)requiresSecureCoding error:(NSError **)error;
 + (NSData *)archivedDataWithRootObject:(id)rootObject;
 + (BOOL)archiveRootObject:(id)rootObject toFile:(NSString *)path;
 + (void)setClassName:(NSString *)codedName forClass:(Class)cls;
@@ -101,6 +103,7 @@ typedef struct offsetDataStruct offsetDataStruct;
     CFMutableDictionaryRef _reservedDictionary;
 }
 
++ (id)unarchivedObjectOfClass:(Class)cls fromData:(NSData *)data error:(NSError **)error;
 + (id)unarchiveObjectWithData:(NSData *)data;
 + (id)unarchiveObjectWithFile:(NSString *)path;
 - (id)initForReadingWithData:(NSData *)data;


### PR DESCRIPTION
There are still a few more unimplemented methods that prevent my test case program (for testing CNLabeledValue) from running properly on Darling.

This PR implements [one of the methods needed](https://developer.apple.com/documentation/foundation/nskeyedarchiver/2962880-archiveddatawithrootobject?language=objc), but since there isn't any documentation for this function, I had to go purely off of guess work. But after messing around with the arguments, I think I got a feel of how the function works.

I also wanted to implement [this method](https://developer.apple.com/documentation/foundation/nskeyedunarchiver/2962884-unarchivedobjectofclass?language=objc) as well for this PR, but based on my observations, it is probably going to be a lot more work to implement. So if I do implement this method, it will be in another PR.

Let me know if you need me to change anything!