### PR TITLE
Add defaultSessionConfiguration to NSURLSessionConfiguration

### DIFF
--- a/include/Foundation/NSURLSession.h
+++ b/include/Foundation/NSURLSession.h
@@ -145,9 +145,10 @@ FOUNDATION_EXPORT NSString * const NSURLSessionDownloadTaskResumeData;
 
 @interface NSURLSessionConfiguration : NSObject <NSCopying>
 
-+ (NSURLSessionConfiguration *)defaultSessionConfiguration;
 + (NSURLSessionConfiguration *)ephemeralSessionConfiguration;
 + (NSURLSessionConfiguration *)backgroundSessionConfiguration:(NSString *)identifier;
+
+@property(class, readonly, strong) NSURLSessionConfiguration *defaultSessionConfiguration;
 
 @property (readonly, copy) NSString *identifier;
 @property NSURLRequestCachePolicy requestCachePolicy;

--- a/include/Foundation/NSURLSessionConfiguration.h
+++ b/include/Foundation/NSURLSessionConfiguration.h
@@ -1,5 +1,0 @@
-#import <Foundation/NSObject.h>
-
-@interface NSURLSessionConfiguration : NSObject
-@end
-


### PR DESCRIPTION
- Removes NSURLSessionConfiguration.h
- Update NSURLSessionConfiguration defaultSessionConfiguration to property
- Implementation added in https://github.com/darlinghq/darling-cfnetwork/pull/2