### PR TITLE
Fixes for unkeyed decoding

### DIFF
--- a/src/NSCoder.m
+++ b/src/NSCoder.m
@@ -450,26 +450,26 @@ static inline const char *nextType(const char *type)
 
 - (CGRect)decodeRect
 {
-    CGRect r;
-    [self decodeValuesOfObjCTypes:@encode(CGRect), &r];
-    return r;
+    float x, y, width, height;
+    [self decodeValuesOfObjCTypes:"ffff", &x, &y, &width, &height];
+    return CGRectMake(x, y, width, height);
 }
 
 - (void)encodeRect:(CGRect)r
 {
-    [self encodeValuesOfObjCTypes:@encode(CGRect), &r];
+    [self encodeValuesOfObjCTypes:"ffff", (float)r.origin.x, (float)r.origin.y, (float)r.size.width, (float)r.size.height];
 }
 
 - (CGSize)decodeSize
 {
-    CGSize sz;
-    [self decodeValuesOfObjCTypes:@encode(CGSize), &sz];
-    return sz;
+    float width, height;
+    [self decodeValuesOfObjCTypes:"ff", &width, &height];
+    return CGSizeMake(width, height);
 }
 
 - (void)encodeSize:(CGSize)sz
 {
-    [self encodeValuesOfObjCTypes:@encode(CGSize), &sz];
+    [self encodeValuesOfObjCTypes:"ff", (float)sz.width, (float)sz.height];
 }
 
 - (CGPoint)decodePoint

--- a/src/NSUnarchiver.m
+++ b/src/NSUnarchiver.m
@@ -13,6 +13,7 @@ Copyright (C) 2020 Lubos Dolezel
 #include <CoreFoundation/CFSet.h>
 #include <string.h>
 #include <dispatch/dispatch.h>
+#include <objc/runtime.h>
 
 static NSMutableDictionary<NSString*,NSString*>* globalClassNameMap;
 
@@ -722,6 +723,7 @@ static unsigned int roundUp(unsigned int size, unsigned int align);
         case '*':
         case '%':
         case ':':
+        case '#':
         {
             NSString* string;
             if(![self decodeSharedString:&string])
@@ -755,6 +757,11 @@ static unsigned int roundUp(unsigned int size, unsigned int align);
             {
                *((SEL*) data) = sel_registerName(cString);
                free(cString);
+            }
+            else if (ch == '#')
+            {
+                *((Class*) data) = objc_getClass(cString);
+                free(cString);
             }
             break;
         }

--- a/src/NSUnarchiver.m
+++ b/src/NSUnarchiver.m
@@ -725,8 +725,11 @@ static unsigned int roundUp(unsigned int size, unsigned int align);
         {
             NSString* string;
             if(![self decodeString:&string])
-                return NO;
-            
+            {
+                rv = NO;
+                break;
+            }
+
             // Freeing of the string seems to be the responsibilty of the caller.
             // NSCoding implementations of Foundation classes all seem to do this.
             char* cString = malloc(string.length + 1);  // +1 because of null-termination

--- a/src/NSUnarchiver.m
+++ b/src/NSUnarchiver.m
@@ -724,7 +724,7 @@ static unsigned int roundUp(unsigned int size, unsigned int align);
         case ':':
         {
             NSString* string;
-            if(![self decodeString:&string])
+            if(![self decodeSharedString:&string])
             {
                 rv = NO;
                 break;


### PR DESCRIPTION
This PR contains fixes to `NSUnarchiver` and `NSCoder` to properly decode the NIB from Apple's [SimpleCocoaApp](https://developer.apple.com/library/archive/samplecode/SimpleCocoaApp/Introduction/Intro.html#//apple_ref/doc/uid/DTS10000403), which uses unkeyed coder.

Please review commit by commit/ I added a explanation for each of the fixes in the commit body.