### PR TITLE
Add symbols for SubEthaEdit app

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,10 +245,13 @@ set(foundation_sources
 	src/NSExtensionContext.m
 	src/NSISO8601DateFormatter.m
 	src/NSScriptObjectSpecifiers.m
+	src/NSScriptCoercionHandler.m
 	src/NSScriptCommand.m
 	src/NSScriptCommandDescription.m
 	src/NSScriptClassDescription.m
+	src/NSScriptSuiteRegistry.m
 	src/NSUserNotification.m
+	src/NSUserScriptTask.m
 	src/NSDateInterval.m
 	src/NSGarbageCollector.m
 	src/NSUnarchiver.m

--- a/include/Foundation/NSScriptCoercionHandler.h
+++ b/include/Foundation/NSScriptCoercionHandler.h
@@ -1,1 +1,4 @@
-// TODO: NSScriptCoercionHandler
+#import <Foundation/NSObject.h>
+
+@interface NSScriptCoercionHandler : NSObject {}
+@end

--- a/include/Foundation/NSScriptSuiteRegistry.h
+++ b/include/Foundation/NSScriptSuiteRegistry.h
@@ -1,1 +1,4 @@
-// TODO: NSScriptSuiteRegistry
+#import <Foundation/NSObject.h>
+
+@interface NSScriptSuiteRegistry : NSObject {}
+@end

--- a/include/Foundation/NSUserScriptTask.h
+++ b/include/Foundation/NSUserScriptTask.h
@@ -1,1 +1,7 @@
-// TODO: NSUserScriptTask
+#import <Foundation/NSObject.h>
+
+@interface NSUserScriptTask : NSObject {}
+@end
+
+@interface NSUserAppleScriptTask : NSUserScriptTask {}
+@end

--- a/src/NSScriptCoercionHandler.m
+++ b/src/NSScriptCoercionHandler.m
@@ -1,0 +1,17 @@
+#import <Foundation/NSScriptCoercionHandler.h>
+#import <Foundation/NSMethodSignature.h>
+#import <Foundation/NSInvocation.h>
+
+@implementation NSScriptCoercionHandler
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
+{
+    return [NSMethodSignature signatureWithObjCTypes: "v@:"];
+}
+
+- (void)forwardInvocation:(NSInvocation *)anInvocation
+{
+    NSLog(@"Stub called: %@ in %@", NSStringFromSelector([anInvocation selector]), [self class]);
+}
+
+@end

--- a/src/NSScriptSuiteRegistry.m
+++ b/src/NSScriptSuiteRegistry.m
@@ -1,0 +1,17 @@
+#import <Foundation/NSScriptSuiteRegistry.h>
+#import <Foundation/NSMethodSignature.h>
+#import <Foundation/NSInvocation.h>
+
+@implementation NSScriptSuiteRegistry
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
+{
+    return [NSMethodSignature signatureWithObjCTypes: "v@:"];
+}
+
+- (void)forwardInvocation:(NSInvocation *)anInvocation
+{
+    NSLog(@"Stub called: %@ in %@", NSStringFromSelector([anInvocation selector]), [self class]);
+}
+
+@end

--- a/src/NSUserScriptTask.m
+++ b/src/NSUserScriptTask.m
@@ -1,0 +1,32 @@
+#import <Foundation/NSUserScriptTask.h>
+#import <Foundation/NSMethodSignature.h>
+#import <Foundation/NSInvocation.h>
+
+@implementation NSUserScriptTask
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
+{
+    return [NSMethodSignature signatureWithObjCTypes: "v@:"];
+}
+
+- (void)forwardInvocation:(NSInvocation *)anInvocation
+{
+    NSLog(@"Stub called: %@ in %@", NSStringFromSelector([anInvocation selector]), [self class]);
+}
+
+
+@end
+
+@implementation NSUserAppleScriptTask
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
+{
+    return [NSMethodSignature signatureWithObjCTypes: "v@:"];
+}
+
+- (void)forwardInvocation:(NSInvocation *)anInvocation
+{
+    NSLog(@"Stub called: %@ in %@", NSStringFromSelector([anInvocation selector]), [self class]);
+}
+
+@end


### PR DESCRIPTION
This is a continue of [darling#1598](https://github.com/darlinghq/darling/pull/1598) and [darling-cocotron#45](https://github.com/darlinghq/darling-cocotron/pull/45) work

<details open><summary>Symbols added</summary>
<p>

  - `_OBJC_CLASS_$_NSScriptCoercionHandler` ([docs](https://developer.apple.com/documentation/foundation/nsscriptcoercionhandler?language=objc))
  - `_OBJC_CLASS_$_NSScriptSuiteRegistry` ([docs](https://developer.apple.com/documentation/foundation/nsscriptsuiteregistry?language=objc))
  - `_OBJC_CLASS_$_NSUserAppleScriptTask` ([docs](https://developer.apple.com/documentation/foundation/nsuserapplescripttask?language=objc))
  - `_OBJC_CLASS_$_NSUserScriptTask` ([docs](https://developer.apple.com/documentation/foundation/nsuserscripttask?language=objc))

</p>
</details> 
