### PR TITLE
Add stubs for Xcode 3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,6 +249,8 @@ set(foundation_sources
 	src/NSScriptCommand.m
 	src/NSScriptCommandDescription.m
 	src/NSScriptClassDescription.m
+	src/NSScriptExecutionContext.m
+	src/NSScriptStandardSuiteCommands.m
 	src/NSScriptSuiteRegistry.m
 	src/NSUserNotification.m
 	src/NSUserScriptTask.m

--- a/include/Foundation/NSScriptStandardSuiteCommands.h
+++ b/include/Foundation/NSScriptStandardSuiteCommands.h
@@ -1,1 +1,24 @@
-// TODO: NSScriptStandardSuiteCommands
+/*
+ This file is part of Darling.
+
+ Copyright (C) 2025 Darling Developers
+
+ Darling is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Darling is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Darling.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#import <Foundation/NSScriptCommand.h>
+
+@interface NSCreateCommand : NSScriptCommand
+
+@end

--- a/src/NSScriptExecutionContext.m
+++ b/src/NSScriptExecutionContext.m
@@ -17,8 +17,20 @@
  along with Darling.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#import <Foundation/NSObject.h>
+#import <Foundation/NSScriptExecutionContext.h>
+#import <Foundation/NSMethodSignature.h>
+#import <Foundation/NSInvocation.h>
 
-@interface NSScriptExecutionContext : NSObject
+@implementation NSScriptExecutionContext
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
+{
+    return [NSMethodSignature signatureWithObjCTypes: "v@:"];
+}
+
+- (void)forwardInvocation:(NSInvocation *)anInvocation
+{
+    NSLog(@"Stub called: %@ in %@", NSStringFromSelector([anInvocation selector]), [self class]);
+}
 
 @end

--- a/src/NSScriptStandardSuiteCommands.m
+++ b/src/NSScriptStandardSuiteCommands.m
@@ -17,8 +17,20 @@
  along with Darling.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#import <Foundation/NSObject.h>
+#import <Foundation/NSScriptStandardSuiteCommands.h>
+#import <Foundation/NSMethodSignature.h>
+#import <Foundation/NSInvocation.h>
 
-@interface NSScriptExecutionContext : NSObject
+@implementation NSCreateCommand
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
+{
+    return [NSMethodSignature signatureWithObjCTypes: "v@:"];
+}
+
+- (void)forwardInvocation:(NSInvocation *)anInvocation
+{
+    NSLog(@"Stub called: %@ in %@", NSStringFromSelector([anInvocation selector]), [self class]);
+}
 
 @end


### PR DESCRIPTION
This adds some stubs that were required when I tried to get Xcode 3.0 working.

Stubs:
- NSCreateCommand
- NSScriptExecutionContext