### PR TITLE
Implement NSDistributedLock

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,8 @@ set(foundation_sources
 	src/NSDictionary.m
 	src/NSDirectoryEnumerator.m
 	src/NSDistributedLock.m
-	src/NSDistributedNotificationCenter.m	src/NSEqualityPredicateOperator.m
+	src/NSDistributedNotificationCenter.m
+	src/NSEqualityPredicateOperator.m
 	src/NSException.m
 	src/NSExpression.m
 	src/NSExternals.m

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,8 +66,8 @@ set(foundation_sources
 	src/NSDecimalNumber.m
 	src/NSDictionary.m
 	src/NSDirectoryEnumerator.m
-	src/NSDistributedNotificationCenter.m
-	src/NSEqualityPredicateOperator.m
+	src/NSDistributedLock.m
+	src/NSDistributedNotificationCenter.m	src/NSEqualityPredicateOperator.m
 	src/NSException.m
 	src/NSExpression.m
 	src/NSExternals.m

--- a/include/Foundation/NSDistributedLock.h
+++ b/include/Foundation/NSDistributedLock.h
@@ -1,3 +1,22 @@
+/*
+ This file is part of Darling.
+
+ Copyright (C) 2026 redminote11tech
+
+ Darling is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Darling is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Darling.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 #import <Foundation/NSObject.h>
 
 @class NSString, NSDate;
@@ -9,6 +28,8 @@ NS_ASSUME_NONNULL_BEGIN
     BOOL _isLocked;
 }
 
+@property (readonly, copy) NSDate *lockDate;
+
 + (nullable NSDistributedLock *)lockWithPath:(NSString *)path;
 - (nullable instancetype)init; // NS_UNAVAILABLE
 - (nullable instancetype)initWithPath:(NSString *)path NS_DESIGNATED_INITIALIZER;
@@ -16,7 +37,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)tryLock;
 - (void)unlock;
 - (void)breakLock;
-@property (readonly, copy) NSDate *lockDate;
 
 @end
 

--- a/include/Foundation/NSDistributedLock.h
+++ b/include/Foundation/NSDistributedLock.h
@@ -1,1 +1,23 @@
-// TODO: NSDistributedLock
+#import <Foundation/NSObject.h>
+
+@class NSString, NSDate;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSDistributedLock : NSObject {
+    NSString *_path;
+    BOOL _isLocked;
+}
+
++ (nullable NSDistributedLock *)lockWithPath:(NSString *)path;
+- (nullable instancetype)init; // NS_UNAVAILABLE
+- (nullable instancetype)initWithPath:(NSString *)path NS_DESIGNATED_INITIALIZER;
+
+- (BOOL)tryLock;
+- (void)unlock;
+- (void)breakLock;
+@property (readonly, copy) NSDate *lockDate;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/NSDistributedLock.m
+++ b/src/NSDistributedLock.m
@@ -1,0 +1,124 @@
+#import <Foundation/NSDistributedLock.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSDate.h>
+#import <Foundation/NSException.h>
+#import <Foundation/NSFileManager.h>
+
+#include <sys/stat.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+
+@implementation NSDistributedLock
+
++ (nullable NSDistributedLock *)lockWithPath:(NSString *)path {
+    return [[[self alloc] initWithPath:path] autorelease];
+}
+
+- (nullable instancetype)init {
+    return [self initWithPath:@""];
+}
+
+- (nullable instancetype)initWithPath:(NSString *)path {
+    self = [super init];
+    if (self) {
+        // According to Apple docs, path must be an absolute path
+        if (!path || ![path isAbsolutePath]) {
+            [self release];
+            return nil;
+        }
+        
+        _path = [path copy];
+        _isLocked = NO;
+    }
+    return self;
+}
+
+- (void)dealloc {
+    if (_isLocked) {
+        [self unlock];
+    }
+    [_path release];
+    [super dealloc];
+}
+
+- (BOOL)tryLock {
+    if (_isLocked) {
+        return YES; // We already hold it
+    }
+
+    // Atomically create the directory
+    const char *cPath = [_path fileSystemRepresentation];
+    if (mkdir(cPath, 0777) == 0) {
+        // Success: we created the directory and acquired the lock
+        _isLocked = YES;
+        return YES;
+    }
+
+    // If it failed because it already exists, someone else holds the lock
+    if (errno == EEXIST) {
+        return NO;
+    }
+
+    // For any other error (permissions, read-only FS), we also return NO
+    return NO;
+}
+
+- (void)unlock {
+    if (!_isLocked) {
+        [NSException raise:NSGenericException format:@"NSDistributedLock: Attempt to unlock a lock not held by this instance (path: %@)", _path];
+        return;
+    }
+
+    const char *cPath = [_path fileSystemRepresentation];
+    if (rmdir(cPath) != 0) {
+        // It's possible another process forcefully broke our lock
+        if (errno == ENOENT) {
+             _isLocked = NO;
+             return;
+        }
+        [NSException raise:NSGenericException format:@"NSDistributedLock: Failed to remove lock directory at path: %@, error: %s", _path, strerror(errno)];
+    }
+
+    _isLocked = NO;
+}
+
+- (void)breakLock {
+    const char *cPath = [_path fileSystemRepresentation];
+    
+    // We attempt to remove the directory regardless of who owns it.
+    if (rmdir(cPath) == 0) {
+        // Lock broken successfully
+        // If we held the lock locally, we no longer do
+        _isLocked = NO;
+    } else {
+        if (errno != ENOENT) {
+            // It might be an actual file instead of a directory (e.g. if someone else used an incompatible lock mechanism)
+            // or the directory is not empty. Let's try unlink as a fallback, or raise on severe failure.
+            if (unlink(cPath) == 0) {
+                 _isLocked = NO;
+            }
+        }
+    }
+}
+
+- (NSDate *)lockDate {
+    const char *cPath = [_path fileSystemRepresentation];
+    struct stat st;
+    
+    if (stat(cPath, &st) == 0) {
+        // Return the modification or creation time
+        // Apple docs say "date the lock was created"
+#ifdef __APPLE__
+        struct timespec ts = st.st_ctimespec;
+#else
+        // Use mtime on Linux/others as a close approximation of creation time for directories
+        struct timespec ts = st.st_mtim;
+#endif
+        return [NSDate dateWithTimeIntervalSince1970:(NSTimeInterval)ts.tv_sec + ((NSTimeInterval)ts.tv_nsec / 1000000000.0)];
+    }
+    
+    return nil; // Lock does not exist
+}
+
+@end

--- a/src/NSDistributedLock.m
+++ b/src/NSDistributedLock.m
@@ -63,7 +63,7 @@
 
 - (BOOL)tryLock {
     if (_isLocked) {
-        return YES; // We already hold it
+        return NO; // Apple's implementation returns NO if called twice on the same lock object
     }
 
     // Atomically create the directory

--- a/src/NSDistributedLock.m
+++ b/src/NSDistributedLock.m
@@ -89,14 +89,7 @@
     }
 
     const char *cPath = [_path fileSystemRepresentation];
-    if (rmdir(cPath) != 0) {
-        // It's possible another process forcefully broke our lock
-        if (errno == ENOENT) {
-             _isLocked = NO;
-             return;
-        }
-        [NSException raise:NSGenericException format:@"NSDistributedLock: Failed to remove lock directory at path: %@, error: %s", _path, strerror(errno)];
-    }
+    rmdir(cPath); // Ignore errors, as Apple's implementation does not raise exceptions here either
 
     _isLocked = NO;
 }

--- a/src/NSDistributedLock.m
+++ b/src/NSDistributedLock.m
@@ -85,7 +85,6 @@
 
 - (void)unlock {
     if (!_isLocked) {
-        [NSException raise:NSGenericException format:@"NSDistributedLock: Attempt to unlock a lock not held by this instance (path: %@)", _path];
         return;
     }
 

--- a/src/NSDistributedLock.m
+++ b/src/NSDistributedLock.m
@@ -1,3 +1,22 @@
+/*
+ This file is part of Darling.
+
+ Copyright (C) 2026 redminote11tech
+
+ Darling is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Darling is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Darling.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 #import <Foundation/NSDistributedLock.h>
 #import <Foundation/NSString.h>
 #import <Foundation/NSDate.h>
@@ -109,12 +128,7 @@
     if (stat(cPath, &st) == 0) {
         // Return the modification or creation time
         // Apple docs say "date the lock was created"
-#ifdef __APPLE__
         struct timespec ts = st.st_ctimespec;
-#else
-        // Use mtime on Linux/others as a close approximation of creation time for directories
-        struct timespec ts = st.st_mtim;
-#endif
         return [NSDate dateWithTimeIntervalSince1970:(NSTimeInterval)ts.tv_sec + ((NSTimeInterval)ts.tv_nsec / 1000000000.0)];
     }
     


### PR DESCRIPTION
This PR implements the missing `NSDistributedLock` class in Foundation, which is currently just a TODO stub. Many macOS applications rely on this class for cross-process synchronization (often utilizing the file system) and will crash if it is unimplemented.

**Implementation Details:**
* Used the POSIX `mkdir` (Directory Creation) strategy to mirror Apple's and GNUstep's historical implementations.
* This approach guarantees atomic lock acquisition even over network file systems (like NFS) where standard `flock()` or `fcntl()` might fail or be unsupported.
* Updated `CMakeLists.txt` to include the new `NSDistributedLock.m` file.